### PR TITLE
Build VTK-m DataSet from ANARI triangles geometry

### DIFF
--- a/device/CMakeLists.txt
+++ b/device/CMakeLists.txt
@@ -31,6 +31,7 @@ add_library(${PROJECT_NAME} SHARED
   scene/light/Light.cpp
   scene/surface/Surface.cpp
   scene/surface/geometry/Geometry.cpp
+  scene/surface/geometry/Triangle.cpp
   scene/surface/material/Material.cpp
   scene/surface/material/sampler/Sampler.cpp
   scene/volume/Volume.cpp
@@ -41,6 +42,7 @@ add_library(${PROJECT_NAME} SHARED
 target_link_libraries(${PROJECT_NAME}
 PRIVATE
   anari::helium
+  vtkm::cont
   vtkm::worklet
 )
 

--- a/device/array/Array1D.cpp
+++ b/device/array/Array1D.cpp
@@ -2,6 +2,72 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "array/Array1D.h"
+#include "anari/frontend/type_utility.h"
+// C++
+#include <type_traits>
+
+namespace {
+
+template <typename BaseType, int NumComponents>
+struct VTKmTypeImpl
+{
+  using type = vtkm::Vec<BaseType, static_cast<vtkm::IdComponent>(NumComponents)>;
+};
+template <typename BaseType>
+struct VTKmTypeImpl<BaseType, 1>
+{
+  using type = BaseType;
+};
+
+template <int ANARIDataTypeId>
+struct ANARIToVTKmTypeImpl
+{
+  using properties = anari::ANARITypeProperties<ANARIDataTypeId>;
+  using type = typename VTKmTypeImpl<typename properties::base_type, properties::components>::type;
+};
+
+template <int ANARIDataTypeId>
+using ANARIToVTKmType = typename ANARIToVTKmTypeImpl<ANARIDataTypeId>::type;
+
+template <int ANARIDataTypeId>
+struct ConstructArrayHandle
+{
+  using T = ANARIToVTKmType<ANARIDataTypeId>;
+  vtkm::cont::UnknownArrayHandle operator()(const void *memory, vtkm::Id numValues)
+  {
+    return this->DoIt(memory, numValues, std::is_pointer<T>{});
+  }
+
+  vtkm::cont::UnknownArrayHandle DoIt(
+      const void *memory, vtkm::Id numValues, std::false_type /*is_pointer*/)
+  {
+    // TODO: The ANARI interface generally passes arrays in the host memory space.
+    // This can be really inefficient as data is pulled from GPU to CPU, passed to
+    // ANARI, and then copied right back to the GPU. Need an extension to allow
+    // client applications to pass device memory directly.
+    return vtkm::cont::make_ArrayHandle(
+        reinterpret_cast<const T *>(memory), numValues, vtkm::CopyFlag::Off);
+  }
+
+  vtkm::cont::UnknownArrayHandle DoIt(const void *, vtkm::Id, std::true_type /*is_pointer*/)
+  {
+    std::cout << "Cannot convert an array of type "
+              << anari::ANARITypeProperties<ANARIDataTypeId>::type_name
+              << " to VTK-m.\n";
+    return vtkm::cont::UnknownArrayHandle{};
+  }
+};
+template <>
+struct ConstructArrayHandle<ANARI_UNKNOWN>
+{
+  vtkm::cont::UnknownArrayHandle operator()(const void *, vtkm::Id)
+  {
+    std::cout << "Cannot convert an array of type ANARI_UNKNOWN to VTK-m.\n";
+    return vtkm::cont::UnknownArrayHandle{};
+  }
+};
+
+} // anonymous namespace
 
 namespace vtkm_device {
 
@@ -14,6 +80,29 @@ Array1D::Array1D(VTKmDeviceGlobalState *state, const Array1DMemoryDescriptor &d)
 Array1D::~Array1D()
 {
   asVTKmDeviceState(deviceState())->objectCounts.arrays--;
+}
+
+void Array1D::unmap()
+{
+  this->helium::Array1D::unmap();
+  // Invalidate VTK-m ArrayHandle
+  this->m_VTKmArray.ReleaseResources();
+}
+
+vtkm::cont::UnknownArrayHandle Array1D::dataAsVTKmArray() const
+{
+  if (!this->m_VTKmArray.IsValid())
+  {
+    // Pull data from ANARI into VTK-m.
+    vtkm::Id numValues = this->size();
+    const void *memory = this->begin();
+
+    const_cast<Array1D *>(this)->m_VTKmArray =
+        anari::anariTypeInvoke<vtkm::cont::UnknownArrayHandle, ConstructArrayHandle>(
+            this->elementType(), memory, numValues);
+  }
+
+  return this->m_VTKmArray;
 }
 
 } // namespace vtkm_device

--- a/device/array/Array1D.h
+++ b/device/array/Array1D.h
@@ -6,6 +6,8 @@
 #include "../VTKmDeviceGlobalState.h"
 // helium
 #include "helium/array/Array1D.h"
+// VTK-m
+#include <vtkm/cont/UnknownArrayHandle.h>
 
 namespace vtkm_device {
 
@@ -15,6 +17,18 @@ struct Array1D : public helium::Array1D
 {
   Array1D(VTKmDeviceGlobalState *state, const Array1DMemoryDescriptor &d);
   ~Array1D() override;
+
+  void unmap() override;
+
+  /// @brief Return the data for this array wrapped into a VTK-m array handle.
+  ///
+  /// Note: Do not change the contents of the VTK-m array handle. Although the
+  /// data are in a VTK-m array, it is still managed by ANARI, and changing the
+  /// data outside of a map/unmap is forbidden.
+  vtkm::cont::UnknownArrayHandle dataAsVTKmArray() const;
+
+ private:
+  vtkm::cont::UnknownArrayHandle m_VTKmArray;
 };
 
 } // namespace vtkm_device

--- a/device/scene/surface/geometry/Geometry.cpp
+++ b/device/scene/surface/geometry/Geometry.cpp
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "Geometry.h"
+// subtypes
+#include "Triangle.h"
 
 namespace vtkm_device {
 
@@ -18,7 +20,12 @@ Geometry::~Geometry()
 Geometry *Geometry::createInstance(
     std::string_view subtype, VTKmDeviceGlobalState *s)
 {
-  return (Geometry *)new UnknownObject(ANARI_GEOMETRY, s);
+  std::cout << "Creating geometry of type " << subtype << "\n";
+  if (subtype == "triangle")
+    return new Triangle(s);
+  else
+    // This seems insanely dangerous.
+    return (Geometry *)new UnknownObject(ANARI_GEOMETRY, s);
 }
 
 } // namespace vtkm_device

--- a/device/scene/surface/geometry/Geometry.h
+++ b/device/scene/surface/geometry/Geometry.h
@@ -5,6 +5,8 @@
 
 #include "Object.h"
 
+#include <vtkm/cont/DataSet.h>
+
 namespace vtkm_device {
 
 struct Geometry : public Object
@@ -13,6 +15,11 @@ struct Geometry : public Object
   ~Geometry() override;
   static Geometry *createInstance(
       std::string_view subtype, VTKmDeviceGlobalState *s);
+
+  const vtkm::cont::DataSet &getData() const { return this->m_data; }
+
+ protected:
+  vtkm::cont::DataSet m_data;
 };
 
 } // namespace vtkm_device

--- a/device/scene/surface/geometry/Triangle.cpp
+++ b/device/scene/surface/geometry/Triangle.cpp
@@ -1,0 +1,47 @@
+// Copyright 2024 The Khronos Group
+// SPDX-License-Identifier: Apache-2.0
+
+#include "Triangle.h"
+// VTK-m
+#include <vtkm/CellShape.h>
+#include <vtkm/cont/ArrayCopy.h>
+#include <vtkm/cont/ArrayHandleRuntimeVec.h>
+#include <vtkm/cont/CellSetSingleType.h>
+#include <vtkm/cont/UnknownArrayHandle.h>
+
+namespace vtkm_device {
+
+Triangle::Triangle(VTKmDeviceGlobalState* s)
+    : Geometry(s), m_index(this), m_vertexPosition(this)
+{
+}
+
+void Triangle::commit()
+{
+  // Stashing these in a ChangeObserverPtr means that commit will be
+  // called again if the array contents change.
+  this->m_index = getParamObject<Array1D>("primitive.index");
+  this->m_vertexPosition = getParamObject<Array1D>("vertex.position");
+  this->m_index->dataAsVTKmArray().PrintSummary(std::cout, true);
+
+  // Reset data
+  this->m_data = vtkm::cont::DataSet{};
+
+  // Get the connection array.
+  // Note that ANARI provides the connection array as a series of triples whereas
+  // VTK-m wants a flat array of indices. The easist way to do the conversion
+  // (while sharing pointers) is to use ArrayHandleRuntimeVec.
+  vtkm::cont::ArrayHandleRuntimeVec<vtkm::Id> connectionArray(3);
+  vtkm::cont::ArrayCopyShallowIfPossible(this->m_index->dataAsVTKmArray(), connectionArray);
+
+  vtkm::cont::CellSetSingleType<> cellSet;
+  cellSet.Fill(connectionArray.GetNumberOfValues() / 3,
+      vtkm::CELL_SHAPE_TRIANGLE,
+      3,
+      connectionArray.GetComponentsArray());
+  this->m_data.SetCellSet(cellSet);
+
+  this->m_data.AddCoordinateSystem("coords", this->m_vertexPosition->dataAsVTKmArray());
+}
+
+} // namespace vtkm_device

--- a/device/scene/surface/geometry/Triangle.h
+++ b/device/scene/surface/geometry/Triangle.h
@@ -1,0 +1,24 @@
+// Copyright 2024 The Khronos Group
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "Geometry.h"
+#include "array/Array1D.h"
+//helium
+#include <helium/utility/ChangeObserverPtr.h>
+
+namespace vtkm_device {
+
+struct Triangle : Geometry
+{
+  Triangle(VTKmDeviceGlobalState *s);
+
+  void commit() override;
+
+ private:
+  helium::ChangeObserverPtr<Array1D> m_index;
+  helium::ChangeObserverPtr<Array1D> m_vertexPosition;
+};
+
+} // namespace vtkm_device

--- a/device/vtkm_device.json
+++ b/device/vtkm_device.json
@@ -6,7 +6,8 @@
       "anari_core_1_0",
       "anari_core_objects_base_1_0",
       "khr_camera_orthographic",
-      "khr_camera_perspective"
+      "khr_camera_perspective",
+      "khr_geometry_triangle"
     ]
   },
   "objects": [


### PR DESCRIPTION
This is the first attempt at converting ANARI arrays into VTK-m `DataSet` objects that can be rendered by VTK-m. It takes triangles from the `khr_geometry_triangle` specification and builds an explicit set of triangles and coordinate system.

The colors are still not set. That needs to come later.