### PR TITLE
Fix camera setup parameters

### DIFF
--- a/device/camera/Camera.cpp
+++ b/device/camera/Camera.cpp
@@ -25,26 +25,34 @@ Camera *Camera::createInstance(std::string_view type, VTKmDeviceGlobalState *s)
   else if (type == "orthographic")
     return new Orthographic(s);
   else
-    return (Camera *)new UnknownObject(ANARI_CAMERA, s);
+    return new UnknownCamera(s);
 }
 
 void Camera::commit()
 {
-  auto pp = getParam<float3>("position", float3(0.f));
-  auto dd = getParam<float3>("direction", float3(0.f, 0.f, 1.f));
-  this->Position = getParam<vtkm::Vec3f_32>("position", vtkm::Vec3f_32(0.f));
-  this->Dir = vtkm::Normal(
-      getParam<vtkm::Vec3f_32>("direction", vtkm::Vec3f_32(0.f, 0.f, 1.f)));
-  this->Up = vtkm::Normal(
-      getParam<vtkm::Vec3f_32>("up", vtkm::Vec3f_32(0.f, 1.f, 0.f)));
-  this->ImageRegion = vtkm::Vec4f_32(0.f, 0.f, 1.f, 1.f);
-  getParam("imageRegion", ANARI_FLOAT32_BOX2, &this->ImageRegion);
+  this->m_position = getParam<vtkm::Vec3f_32>("position", { 0.f, 0.f, 0.f });
+  this->m_direction = vtkm::Normal(getParam<vtkm::Vec3f_32>("direction", { 0.f, 0.f, -1.f }));
+  this->m_up = vtkm::Normal(getParam<vtkm::Vec3f_32>("up", { 0.f, 1.f, 0.f }));
+  this->m_imageRegion = vtkm::Vec4f_32(0.f, 0.f, 1.f, 1.f);
+  getParam("imageRegion", ANARI_FLOAT32_BOX2, &this->m_imageRegion);
 
-  //std::cout<<"Pos== "<<this->Position<<" pp= "<<pp<<std::endl;
-  //std::cout<<"Dir== "<<this->Dir<<" dd== "<<dd<<std::endl;
-  //std::cout<<"Up== "<<this->Up<<std::endl;
+  std::cout<<"Pos== "<<this->m_position <<std::endl;
+  std::cout<<"Dir== "<<this->m_direction <<std::endl;
+  std::cout<<"Up== "<<this->m_up <<std::endl;
 
   markUpdated();
+}
+
+UnknownCamera::UnknownCamera(VTKmDeviceGlobalState *s) : Camera(s) {};
+
+vtkm::rendering::Camera UnknownCamera::camera(const vtkm::Bounds&) const
+{
+  return {};
+}
+
+bool UnknownCamera::isValid() const
+{
+  return false;
 }
 
 } // namespace vtkm_device

--- a/device/camera/Camera.h
+++ b/device/camera/Camera.h
@@ -23,21 +23,28 @@ struct Camera : public Object
 
   float4 imageRegion() const
   {
-    return float4(this->ImageRegion[0],
-                  this->ImageRegion[1],
-                  this->ImageRegion[2],
-                  this->ImageRegion[3]);
+    return float4(this->m_imageRegion[0],
+                  this->m_imageRegion[1],
+                  this->m_imageRegion[2],
+                  this->m_imageRegion[3]);
   }
 
-  vtkm::rendering::Camera GetCamera() const { return this->camera; }
+  virtual vtkm::rendering::Camera camera(const vtkm::Bounds &bounds) const = 0;
 
  protected:
-  vtkm::Vec3f_32 Position = vtkm::Vec3f_32(0.f,0.f,0.f);
-  vtkm::Vec3f_32 Dir = vtkm::Vec3f_32(0.f,0.f,1.f);
-  vtkm::Vec3f_32 Up = vtkm::Vec3f_32(0.f,1.f,0.f);
-  vtkm::Vec4f_32 ImageRegion;
+  vtkm::Vec3f_32 m_position;
+  vtkm::Vec3f_32 m_direction;
+  vtkm::Vec3f_32 m_up;
+  vtkm::Vec4f_32 m_imageRegion;
+};
 
-  vtkm::rendering::Camera camera;
+struct UnknownCamera : public Camera
+{
+  UnknownCamera(VTKmDeviceGlobalState *s);
+
+  vtkm::rendering::Camera camera(const vtkm::Bounds &) const override;
+
+  bool isValid() const override;
 };
 
 } // namespace vtkm_device

--- a/device/camera/Orthographic.cpp
+++ b/device/camera/Orthographic.cpp
@@ -11,10 +11,34 @@ void Orthographic::commit()
 {
   Camera::commit();
 
-  const float aspect = getParam<float>("aspect", 1.f);
-  const float height = getParam<float>("height", 1.f);
+  this->m_aspect = this->getParam("aspect", vtkm::Float32(1));
+  this->m_height = this->getParam("height", vtkm::Float32(1));
+  this->m_near = this->getParam("near", vtkm::Float32(-1));
+  this->m_far = this->getParam("far", vtkm::Float32(-1));
+}
 
-  vtkm::Vec2f_32 imgPlaneSize(height * aspect, height);
+vtkm::rendering::Camera Orthographic::camera(const vtkm::Bounds &bounds) const
+{
+  // TODO: Implement orthographic projection correctly
+  vtkm::rendering::Camera camera;
+
+  vtkm::Vec3f_64 diagonal = { bounds.X.Length(), bounds.Y.Length(), bounds.Z.Length() };
+  vtkm::Float32 length = static_cast<vtkm::Float32>(vtkm::Magnitude(diagonal));
+
+  camera.SetPosition(this->m_position);
+  camera.SetLookAt(this->m_position + (length * this->m_direction));
+  camera.SetViewUp(this->m_up);
+  camera.SetClippingRange(
+      (this->m_near > 0) ? this->m_near : (0.001f * length),
+      (this->m_far > 0) ? this->m_far : (100.f * length));
+#if 0
+  camera.SetViewport(this->m_imageRegion[0],
+                     this->m_imageRegion[2],
+                     this->m_imageRegion[1],
+                     this->m_imageRegion[3]);
+#endif
+
+  return camera;
 }
 
 } // namespace vtkm_device

--- a/device/camera/Orthographic.h
+++ b/device/camera/Orthographic.h
@@ -11,6 +11,14 @@ struct Orthographic : public Camera
 {
   Orthographic(VTKmDeviceGlobalState *s);
   void commit() override;
+
+  vtkm::rendering::Camera camera(const vtkm::Bounds &bounds) const override;
+
+ private:
+  vtkm::Float32 m_aspect;
+  vtkm::Float32 m_height;
+  vtkm::Float32 m_near;
+  vtkm::Float32 m_far;
 };
 
 } // namespace vtkm_device

--- a/device/camera/Perspective.h
+++ b/device/camera/Perspective.h
@@ -11,6 +11,14 @@ struct Perspective : public Camera
 {
   Perspective(VTKmDeviceGlobalState *s);
   void commit() override;
+
+  vtkm::rendering::Camera camera(const vtkm::Bounds &bounds) const override;
+
+ private:
+  vtkm::Float32 m_fovy;
+  vtkm::Float32 m_aspect;
+  vtkm::Float32 m_near;
+  vtkm::Float32 m_far;
 };
 
 } // namespace vtkm_device

--- a/device/frame/Frame.cpp
+++ b/device/frame/Frame.cpp
@@ -212,9 +212,9 @@ void Frame::renderFrame()
       std::fill(m_pixelBuffer.begin(), m_pixelBuffer.end(), 0);
     } else {
       const auto &instances = this->m_world->instances();
-      auto camera = this->m_camera->GetCamera();
+      auto camera = this->m_camera->camera(this->m_world->bounds());
 
-#if 0
+#if 1
       std::cout << "\n\nANARI camera:" << std::endl;
       camera.Print();
 #endif
@@ -223,7 +223,6 @@ void Frame::renderFrame()
       bool doVTKm = false;
       if ((instances.size() > 0)
           && (instances[0]->group()->volumes().size() > 0)) {
-        auto instances = this->m_world->instances();
         if (instances[0]->group()->volumes().size() > 0)
           doVTKm = true;
       }

--- a/device/scene/Group.cpp
+++ b/device/scene/Group.cpp
@@ -101,43 +101,6 @@ static inline float MAXELEM(const float3& a)
   return std::max(a[0], std::max(a[1],a[2]));
 }
 
-//static inline float MAX(const float& a, const float& b)
-//{
-//  return a > b ? a : b;
-//}
-
-void Group::intersectVolumes(VolumeRay &ray) const
-{
-  Volume *originalVolume = ray.volume;
-  box1 t = ray.t;
-
-  for (auto *v : volumes())
-  {
-    if (!v->isValid())
-      continue;
-
-    const box3 bounds = v->bounds();
-    const float3 mins = (bounds.lower - ray.org) * (1.f / ray.dir);
-    const float3 maxs = (bounds.upper - ray.org) * (1.f / ray.dir);
-
-    const float3 nears = MIN(mins, maxs);
-    const float3 fars = MAX(mins, maxs);
-
-    const box1 lt(MAXELEM(nears), MINELEM(fars));
-
-    //Check for hit..
-    if (lt.lower < lt.upper && (!ray.volume || lt.lower < t.lower))
-    {
-      t.lower = CLAMP(lt.lower, t);
-      t.upper = CLAMP(lt.upper, t);
-      ray.volume = v;
-    }
-  }
-
-  if (ray.volume != originalVolume)
-    ray.t = t;
-}
-
 
 void Group::cleanup()
 {

--- a/device/scene/Group.h
+++ b/device/scene/Group.h
@@ -25,8 +25,6 @@ struct Group : public Object
   const std::vector<Surface *> &surfaces() const;
   const std::vector<Volume *> &volumes() const;
 
-    void intersectVolumes(VolumeRay &ray) const;
-
 
  private:
   void cleanup();

--- a/device/scene/World.h
+++ b/device/scene/World.h
@@ -4,6 +4,8 @@
 #pragma once
 
 #include "Instance.h"
+// VTK-m
+#include <vtkm/Bounds.h>
 
 namespace vtkm_device {
 
@@ -21,11 +23,11 @@ struct World : public Object
 
   const std::vector<Instance *> &instances() const;
 
-  void intersectVolumes(VolumeRay &ray) const;
-
   const Instance *instanceFromRay(const Ray &ray) const { return this->instances()[ray.instID]; }
   const Instance *instanceFromRay(const VolumeRay &ray) const { return this->instances()[ray.instID]; }
   const Surface *surfaceFromRay(const Ray &ray) const { return instanceFromRay(ray)->group()->surfaces()[ray.geomID]; }
+
+  const vtkm::Bounds &bounds() const { return this-> m_bounds; }
 
  private:
   void cleanup();
@@ -39,6 +41,8 @@ struct World : public Object
   bool m_addZeroInstance{false};
   helium::IntrusivePtr<Group> m_zeroGroup;
   helium::IntrusivePtr<Instance> m_zeroInstance;
+
+  vtkm::Bounds m_bounds;
 };
 
 } // namespace vtkm_device

--- a/device/scene/surface/Surface.cpp
+++ b/device/scene/surface/Surface.cpp
@@ -42,6 +42,11 @@ const Material *Surface::material() const
   return m_material.ptr;
 }
 
+vtkm::Bounds Surface::bounds() const
+{
+  return this->geometry()->getDataSet().GetCoordinateSystem().GetBounds();
+}
+
 bool Surface::isValid() const
 {
   return m_geometry && m_material && m_geometry->isValid()

--- a/device/scene/surface/Surface.h
+++ b/device/scene/surface/Surface.h
@@ -5,6 +5,8 @@
 
 #include "geometry/Geometry.h"
 #include "material/Material.h"
+// VTK-m
+#include <vtkm/Bounds.h>
 
 namespace vtkm_device {
 
@@ -18,6 +20,8 @@ struct Surface : public Object
   uint32_t id() const {return m_id;}
   const Geometry *geometry() const;
   const Material *material() const;
+
+  vtkm::Bounds bounds() const;
 
   bool isValid() const override;
 

--- a/device/scene/volume/TransferFunction1D.cpp
+++ b/device/scene/volume/TransferFunction1D.cpp
@@ -114,14 +114,9 @@ const SpatialField *TransferFunction1D::spatialField() const
   return this->m_spatialField.ptr;
 }
 
-box3 TransferFunction1D::bounds() const
+vtkm::Bounds TransferFunction1D::bounds() const
 {
-  auto dsBounds = this->m_spatialField->getDataSet().GetCoordinateSystem().GetBounds();
-  float3 minC(dsBounds.X.Min, dsBounds.Y.Min, dsBounds.Z.Min);
-  float3 maxC(dsBounds.X.Max, dsBounds.Y.Max, dsBounds.Z.Max);
-  box3 bounds(minC, maxC);
-
-  return bounds;
+  return this->m_spatialField->getDataSet().GetCoordinateSystem().GetBounds();
 }
 
 vtkm::rendering::Actor *TransferFunction1D::actor() const

--- a/device/scene/volume/TransferFunction1D.h
+++ b/device/scene/volume/TransferFunction1D.h
@@ -23,7 +23,7 @@ struct TransferFunction1D : public Volume
   void commit() override;
 
   const SpatialField *spatialField() const;
-  box3 bounds() const override;
+  vtkm::Bounds bounds() const override;
   vtkm::rendering::Actor *actor() const override;
   vtkm::rendering::MapperVolume *mapper() const override;
 

--- a/device/scene/volume/Volume.cpp
+++ b/device/scene/volume/Volume.cpp
@@ -39,9 +39,9 @@ UnknownVolume::UnknownVolume(VTKmDeviceGlobalState *d) : Volume(d)
 {
 }
 
-box3 UnknownVolume::bounds() const
+vtkm::Bounds UnknownVolume::bounds() const
 {
-  return box3{};
+  return vtkm::Bounds{};
 }
 
 vtkm::rendering::Actor *UnknownVolume::actor() const

--- a/device/scene/volume/Volume.h
+++ b/device/scene/volume/Volume.h
@@ -6,6 +6,7 @@
 #include "Object.h"
 #include "VTKmTypes.h"
 // VTK-m
+#include <vtkm/Bounds.h>
 #include <vtkm/cont/DataSet.h>
 #include <vtkm/rendering/Actor.h>
 #include <vtkm/rendering/Mapper.h>
@@ -23,7 +24,7 @@ struct Volume : public Object
 
   uint32_t id() const;
 
-  virtual box3 bounds() const = 0;
+  virtual vtkm::Bounds bounds() const = 0;
   virtual vtkm::rendering::Actor *actor() const = 0;
   virtual vtkm::rendering::Mapper *mapper() const = 0;
 
@@ -37,7 +38,7 @@ struct UnknownVolume : public Volume
 {
   UnknownVolume(VTKmDeviceGlobalState *d);
 
-  box3 bounds() const override;
+  vtkm::Bounds bounds() const override;
   vtkm::rendering::Actor *actor() const override;
   vtkm::rendering::Mapper *mapper() const override;
   bool isValid() const override;


### PR DESCRIPTION
The camera clipping range was not being set correctly. Get the clipping range from the client or set it up from the bounds if not provided.

Also fix some issues with the lookat position, which is also now sized by the bounds.