### PR TITLE
Fix color space of transfer function

### DIFF
--- a/device/scene/volume/TransferFunction1D.cpp
+++ b/device/scene/volume/TransferFunction1D.cpp
@@ -130,7 +130,7 @@ void TransferFunction1D::finalize()
   }
 
   // Reset and fill color table
-  this->m_colorTable = viskores::cont::ColorTable(viskores::ColorSpace::Lab);
+  this->m_colorTable = viskores::cont::ColorTable(viskores::ColorSpace::RGB);
   bool colorsHaveAlpha = false;
   if (this->m_colorArray) {
     // Convert to Viskores colors


### PR DESCRIPTION
The color space was set to interpolate in CIELAB space, This is generally a good thing, but can be unexpected in a graphics system. It was giving inconsistent colors from other devices.