### PR TITLE
Fix crash when reloading arrays

### DIFF
--- a/device/array/Array1D.cpp
+++ b/device/array/Array1D.cpp
@@ -21,7 +21,7 @@ void Array1D::unmap()
 {
   this->helium::Array1D::unmap();
   // Invalidate Viskores ArrayHandle
-  this->m_ViskoresArray.ReleaseResources();
+  this->m_ViskoresArray = viskores::cont::UnknownArrayHandle{};
 }
 
 viskores::cont::UnknownArrayHandle Array1D::dataAsViskoresArray() const


### PR DESCRIPTION
There was an error in `Array1D` where when the data were unmapped, it
"invalidated" the associated Viskores `UnknownArrayHandle` by releasing
the resources. However, this does not actually invalidate the array. It
just sets the size to zero. The next time the array was set and used,
it registered as a valid array and therefore skipped pulling the new
array.

This fix properly invalidates the `UnknownArrayHandle` by resetting it
to a new object. This will automatically release resources of the array
is not still used elsewhere.

Also added an additional check for invalid objects that was causing
crashes while checking bounds.