### PR TITLE
Fix material update

### DIFF
--- a/device/scene/surface/Surface.cpp
+++ b/device/scene/surface/Surface.cpp
@@ -5,7 +5,9 @@
 
 namespace viskores_device {
 
-Surface::Surface(ViskoresDeviceGlobalState *s) : Object(ANARI_SURFACE, s) {}
+Surface::Surface(ViskoresDeviceGlobalState *s)
+    : Object(ANARI_SURFACE, s), m_geometry(this), m_material(this)
+{}
 
 Surface::~Surface() = default;
 
@@ -33,12 +35,12 @@ void Surface::finalize()
 
 const Geometry *Surface::geometry() const
 {
-  return m_geometry.ptr;
+  return m_geometry.get();
 }
 
 const Material *Surface::material() const
 {
-  return m_material.ptr;
+  return m_material.get();
 }
 
 viskores::Bounds Surface::bounds() const

--- a/device/scene/surface/Surface.h
+++ b/device/scene/surface/Surface.h
@@ -36,8 +36,8 @@ struct Surface : public Object
 
  private:
   uint32_t m_id{~0u};
-  helium::IntrusivePtr<Geometry> m_geometry;
-  helium::IntrusivePtr<Material> m_material;
+  helium::ChangeObserverPtr<Geometry> m_geometry;
+  helium::ChangeObserverPtr<Material> m_material;
 
   std::shared_ptr<viskores::rendering::Actor> m_actor;
 };


### PR DESCRIPTION
The matte material properties were not updating when they were changed between renders. This has been fixed by putting the material properties in a change pointer that will have their properties updated when the surface is updated.