### PR TITLE
approximate physicallyBased material using Matte

### DIFF
--- a/device/scene/surface/material/Material.cpp
+++ b/device/scene/surface/material/Material.cpp
@@ -57,6 +57,8 @@ Material *Material::createInstance(
 {
   if (subtype == "matte") {
     return new MatteMaterial(s);
+  } else if (subtype == "physicallyBased") {
+    return new MatteMaterial(s, true);
   } else {
     return new UnknownMaterial(s);
   }

--- a/device/scene/surface/material/MatteMaterial.cpp
+++ b/device/scene/surface/material/MatteMaterial.cpp
@@ -4,22 +4,24 @@
 
 namespace viskores_device {
 
-MatteMaterial::MatteMaterial(ViskoresDeviceGlobalState *d)
-    : Material(d), m_sampler(this)
+MatteMaterial::MatteMaterial(ViskoresDeviceGlobalState *d, bool approximatePBR)
+    : Material(d), m_approximatePBR(approximatePBR), m_sampler(this)
 {}
 
 void MatteMaterial::commitParameters()
 {
-  this->m_sampler = this->getParamObject<Sampler>("color");
+  const char *colorName = this->m_approximatePBR ? "baseColor" : "color";
+
+  this->m_sampler = this->getParamObject<Sampler>(colorName);
   this->m_colorAttribute =
-      helium::attributeFromString(this->getParamString("color", "none"));
-  this->m_color = this->getParam("color", viskores::Vec3f_32{0.8, 0.8, 0.8});
+      helium::attributeFromString(this->getParamString(colorName, "none"));
+  this->m_color = this->getParam(colorName, viskores::Vec3f_32{0.8, 0.8, 0.8});
   this->m_color = viskores::Min(
       viskores::Max(this->m_color, {0.f, 0.f, 0.f}), {1.f, 1.f, 1.f});
   // TODO: Implement sampler
 
   this->m_opacityAttribute =
-      helium::attributeFromString(this->getParamString("color", "none"));
+      helium::attributeFromString(this->getParamString("opacity", "none"));
   this->m_opacity = this->getParam("opacity", viskores::Float32{1.0f});
   // TODO: Implement sampler
 
@@ -41,10 +43,11 @@ std::shared_ptr<viskores::rendering::Actor> MatteMaterial::createActor(
   if (this->m_sampler && this->m_sampler->isValid()) {
     actor = this->m_sampler->createActor(data);
     if (!actor) {
-      this->reportMessage(ANARI_SEVERITY_WARNING, "could not create actor for sampler");
+      this->reportMessage(
+          ANARI_SEVERITY_WARNING, "could not create actor for sampler");
     }
-  } 
-  
+  }
+
   if (!actor) {
     viskores::cont::ColorTable colorTable(viskores::ColorSpace::RGB);
     viskores::cont::Field colorField;

--- a/device/scene/surface/material/MatteMaterial.h
+++ b/device/scene/surface/material/MatteMaterial.h
@@ -9,7 +9,7 @@ namespace viskores_device {
 
 struct MatteMaterial : public Material
 {
-  MatteMaterial(ViskoresDeviceGlobalState *d);
+  MatteMaterial(ViskoresDeviceGlobalState *d, bool approximatePBR = false);
 
   void commitParameters() override;
   void finalize() override;
@@ -50,6 +50,8 @@ struct MatteMaterial : public Material
   }
 
  private:
+  bool m_approximatePBR{false};
+
   helium::ChangeObserverPtr<Sampler> m_sampler;
   helium::Attribute m_colorAttribute;
   viskores::Vec3f_32 m_color;

--- a/device/viskores_device.json
+++ b/device/viskores_device.json
@@ -9,7 +9,9 @@
       "khr_camera_perspective",
       "khr_geometry_triangle",
       "khr_material_matte",
+      "khr_material_physically_based",
       "khr_sampler_image1d",
+      "khr_spatial_field_structured_regular",
       "khr_volume_transfer_function1d"
     ]
   },


### PR DESCRIPTION
This just reuses the `matte` material when `physicallyBased` is requested. Gives the same look as helide and at least permits more scenes to show something.

<img width="1976" height="1212" alt="image" src="https://github.com/user-attachments/assets/a759edcd-ff8b-48d1-b8cb-222b4bd84719" />
